### PR TITLE
current downstream dataset support online feat with minimal modification

### DIFF
--- a/config/downstream.yaml
+++ b/config/downstream.yaml
@@ -6,6 +6,7 @@ dataloader:
 
   data_path: 'data/libri_fmllr_cmvn'                    # Source data path, 'data/libri_fmllr_cmvn', or 'data/libri_mfcc_cmvn', or 'data/libri_mel160_subword5000' for different preprocessing features
   phone_path: 'data/cpc_phone'                          # phone boundary label data path for the phone classification task. set to 'data/libri_phone' or 'data/cpc_phone'
+  libri_root: '/home/leo/d/datasets/LibriSpeech'        # only used when extract features on-the-fly
   train_set: ['train-clean-100']                        # ['train-clean-100', 'train-clean-360', 'train-other-500'] for pre-training. ['train-clean-360'] or ['train-clean-100'] for libri phone exp or cpc phone exp, respectively.
   dev_set: ['dev-clean']                                #
   test_set: ['test-clean']                              #

--- a/run_downstream.py
+++ b/run_downstream.py
@@ -18,7 +18,7 @@ import argparse
 import numpy as np
 from shutil import copyfile
 from dataloader import get_Dataloader
-from transformer.nn_transformer import TRANSFORMER, DUAL_TRANSFORMER
+from transformer.nn_transformer import TRANSFORMER
 from downstream.model import dummy_upstream, LinearClassifier, RnnClassifier
 from downstream.runner import Runner
 
@@ -126,6 +126,9 @@ def get_upstream_model(args):
 # GET DATALOADER #
 ##################
 def get_dataloader(args, dataloader_config):
+    pretrain_config = torch.load(args.ckpt, map_location='cpu')['Settings']['Config']
+    if 'online' in pretrain_config:
+        dataloader_config['online_config'] = pretrain_config['online']
 
     if not os.path.exists(dataloader_config['data_path']):
         raise RuntimeError('[run_downstream] - Data path not valid:', dataloader_config['data_path'])    

--- a/run_downstream.py
+++ b/run_downstream.py
@@ -18,7 +18,7 @@ import argparse
 import numpy as np
 from shutil import copyfile
 from dataloader import get_Dataloader
-from transformer.nn_transformer import TRANSFORMER
+from transformer.nn_transformer import TRANSFORMER, DUAL_TRANSFORMER
 from downstream.model import dummy_upstream, LinearClassifier, RnnClassifier
 from downstream.runner import Runner
 

--- a/transformer/nn_transformer.py
+++ b/transformer/nn_transformer.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 from functools import lru_cache
 from distutils.util import strtobool
 from transformer.model import TransformerConfig, TransformerModel
+from utility.preprocessor import OnlinePreprocessor
 
 
 ###############
@@ -91,6 +92,18 @@ class TRANSFORMER(nn.Module):
             self.weight = nn.Parameter(torch.ones(self.num_layers) / self.num_layers)
 
         # Build model
+        if 'online' in self.config:
+            def get_preprocessor(online_config):
+                # load the same preprocessor as pretraining stage
+                upstream_feat = online_config['input']
+                upstream_feat['channel'] = 0
+                preprocessor = OnlinePreprocessor(**online_config, feat_list=[upstream_feat])
+                upstream_feat = preprocessor()[0]
+                upstream_input_dim = upstream_feat.size(-1)
+                return preprocessor, upstream_input_dim
+            preprocessor, inp_dim = get_preprocessor(self.config['online'])
+            self.preprocessor = preprocessor
+
         self.inp_dim = inp_dim if inp_dim > 0 else self.config['transformer']['input_dim']
         self.device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
         self.model = TransformerModel(self.model_config, self.inp_dim).to(self.device)
@@ -281,6 +294,9 @@ class TRANSFORMER(nn.Module):
 
 
     def forward(self, x):
+        if 'online' in self.config:
+            x = self.preprocessor(x.transpose(1, 2))[0]
+
         if self.no_grad:
             with torch.no_grad():
                 self.model.eval()


### PR DESCRIPTION
- 在 Speaker_Dataset 中直接將原本 load npy 的路徑，改成 load 相對應的 waveform，即為原 LibriSpeech dastaset 資料夾裡的 flac 檔 。
- 簡單修改 nn_transformer，偵測如果 upstream model 是用 online preprocessor pretrain 過的，就要建構出完全一樣的 preprocessor，將 forward 進來的 waveform 經由 preprocessor 變成 feature。